### PR TITLE
Reset top spacing on homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -34,7 +34,7 @@ export default function Home() {
 
   return (
     <Layout>
-      <section className="flex flex-col items-center justify-center min-h-screen bg-gray-50 text-center px-4">
+      <section className="flex flex-col items-center justify-center min-h-screen bg-gray-50 text-center px-4 mt-0 pt-0">
         <h1 className="text-4xl font-bold mb-4 text-gray-800">
           Apartman Aidat Takip Sistemi
         </h1>


### PR DESCRIPTION
## Summary
- Ensure hero section on homepage has zero top margin and padding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688fc32d6e5c8325bcbb9840adcd7dd6